### PR TITLE
Use tfvars file to supply variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deploy/variables.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+# Configuration files:
 deploy/variables.tfvars
+tagengine.ini

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -1,11 +1,9 @@
 variable "tag_engine_project" {
     type = string
-    default = "tag-engine-vanilla-337221"
 }
 
 variable "bigquery_project" {
      type = string
-     default = "warehouse-337221"
 }
 
 variable "app_engine_region" {

--- a/tagengine.ini
+++ b/tagengine.ini
@@ -1,6 +1,0 @@
-[DEFAULT]
-TAG_ENGINE_PROJECT = tag-engine-vanilla-337221
-QUEUE_REGION = us-central1
-INJECTOR_QUEUE = tag-engine-injector
-WORK_QUEUE = tag-engine-work
-#ZETA_URL = https://us-central1-tag-engine-283315.cloudfunctions.net/zeta # used only for tag propagations


### PR DESCRIPTION
I recommend letting the user define a separate `variables.tfvars` file instead of modifying the existing `variables.tf`, which should only be used for default values. This PR also removes the default values for the project IDs, since those will be different for every user. FOr the same reason, it removes the `tagengine.ini` file.